### PR TITLE
Fix proto src imports with proto_srcs rule

### DIFF
--- a/remote_execution/oss/google_api_proto/BUCK
+++ b/remote_execution/oss/google_api_proto/BUCK
@@ -1,4 +1,4 @@
-load("@fbcode//buck2:proto_defs.bzl", "rust_protobuf_library")
+load("@fbcode//buck2:proto_defs.bzl", "rust_protobuf_library", "proto_srcs")
 
 oncall("build_infra")
 
@@ -12,4 +12,10 @@ rust_protobuf_library(
         "fbsource//third-party/rust:serde",
         "//buck2/app/buck2_data:buck2_data",
     ],
+)
+
+proto_srcs(
+    name = "google_api_proto_srcs",
+    srcs = glob(["proto/**/*.proto"]),
+    visibility = ["PUBLIC"],
 )

--- a/remote_execution/oss/re_grpc_proto/BUCK
+++ b/remote_execution/oss/re_grpc_proto/BUCK
@@ -1,4 +1,4 @@
-load("@fbcode//buck2:proto_defs.bzl", "rust_protobuf_library")
+load("@fbcode//buck2:proto_defs.bzl", "rust_protobuf_library", "proto_srcs")
 
 oncall("build_infra")
 
@@ -6,11 +6,20 @@ rust_protobuf_library(
     name = "re_grpc_proto",
     srcs = glob(["src/**/*.rs"]),
     build_script = "build.rs",
-    protos = glob(["proto/**/*.proto"]),
+    proto_srcs = ":re_grpc_proto_srcs",
     deps = [
         "fbsource//third-party/rust:prost-types",
         "fbsource//third-party/rust:serde",
         "//buck2/app/buck2_data:buck2_data",
         "//buck2/remote_execution/oss/google_api_proto:google_api_proto",
     ],
+)
+
+proto_srcs(
+    name = "re_grpc_proto_srcs",
+    srcs = glob(["proto/**/*.proto"]),
+    deps = [
+        "//buck2/remote_execution/oss/google_api_proto:google_api_proto_srcs",
+    ],
+    visibility = ["PUBLIC"],
 )

--- a/remote_execution/oss/re_grpc_proto/build.rs
+++ b/remote_execution/oss/re_grpc_proto/build.rs
@@ -7,6 +7,7 @@
  * of this source tree.
  */
 
+use std::env;
 use std::io;
 
 fn main() -> io::Result<()> {
@@ -14,6 +15,12 @@ fn main() -> io::Result<()> {
         "proto/build/bazel/remote/execution/v2/remote_execution.proto",
         "proto/build/bazel/semver/semver.proto",
     ];
+
+    let includes = if let Ok(path) = env::var("BUCK_PROTO_SRCS") {
+        vec![path]
+    } else {
+        vec!["./proto/".to_owned(), "../google_api_proto/proto".to_owned()]
+    };
 
     let builder = buck2_protoc_dev::configure();
     unsafe { builder.setup_protoc() }
@@ -74,5 +81,5 @@ fn main() -> io::Result<()> {
             "build.bazel.remote.execution.v2.ExecutedActionMetadata.auxiliary_metadata",
             "#[serde(with = \"google_api_proto::serialize_vec_any\")]",
         )
-        .compile(proto_files, &["./proto/", "../google_api_proto/proto"])
+        .compile(proto_files, &includes)
 }


### PR DESCRIPTION
## Summary
- preserve directory structure in `proto_srcs` rule so imports like `google/api/annotations.proto` work
- expose google API protos via `proto_srcs` target
- switch RE gRPC protos to use `proto_srcs` and depend on Google API protos
- use `BUCK_PROTO_SRCS` in RE gRPC build script

## Testing
- `cargo test -p buck2_protoc_dev --quiet`
- `python3 test.py --lint-rust-only` *(fails: 'cargo-clippy' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c51b11da0832f8ec921545a94f01c